### PR TITLE
add support for chromedriver logging config

### DIFF
--- a/lib/kimurai/browser_builder/selenium_chrome_builder.rb
+++ b/lib/kimurai/browser_builder/selenium_chrome_builder.rb
@@ -23,6 +23,7 @@ module Kimurai::BrowserBuilder
       Capybara.register_driver :selenium_chrome do |app|
         # Create driver options
         opts = { args: %w[--disable-gpu --no-sandbox --disable-translate] }
+        service_args = []
 
         # Provide custom chrome browser path:
         if chrome_path = Kimurai.configuration.selenium_chrome_path
@@ -109,8 +110,15 @@ module Kimurai::BrowserBuilder
           end
         end
 
+        # Verbose logging to file
+        if chrome_logging_path = @config[:chrome_logging_path]
+          logger.debug "BrowserBuilder (selenium_chrome): enabled verbose logging to #{chrome_logging_path}"
+          service_args << '--verbose'
+          service_args << "--log-path=#{chrome_logging_path}"
+        end
+
         chromedriver_path = Kimurai.configuration.chromedriver_path || "/usr/local/bin/chromedriver"
-        service = Selenium::WebDriver::Service.chrome(path: chromedriver_path)
+        service = Selenium::WebDriver::Service.chrome(path: chromedriver_path, args: service_args)
         Capybara::Selenium::Driver.new(app, browser: :chrome, options: driver_options, service: service)
       end
 

--- a/lib/kimurai/browser_builder/selenium_chrome_builder.rb
+++ b/lib/kimurai/browser_builder/selenium_chrome_builder.rb
@@ -112,9 +112,14 @@ module Kimurai::BrowserBuilder
 
         # Verbose logging to file
         if chrome_logging_path = @config[:chrome_logging_path]
-          logger.debug "BrowserBuilder (selenium_chrome): enabled verbose logging to #{chrome_logging_path}"
-          service_args << '--verbose'
-          service_args << "--log-path=#{chrome_logging_path}"
+          if File.directory?(chrome_logging_path)
+            log_file_path = chrome_logging_path.join("chromium_#{Time.current.strftime('%m_%e_%y_%H_%M_%S')}.log")
+            logger.debug "BrowserBuilder (selenium_chrome): enabled verbose logging to #{log_file_path}"
+            service_args << '--verbose'
+            service_args << "--log-path=#{log_file_path}"
+          else
+            logger.error 'BrowserBuilder (selenium_chrome): :chrome_logging_path must be an existing directory'
+          end
         end
 
         chromedriver_path = Kimurai.configuration.chromedriver_path || "/usr/local/bin/chromedriver"


### PR DESCRIPTION
Adds a way to set a `chrome_logging_path` option when making Kimurai scrapes. If this is set, it includes the arguments `--verbose --log-path=` to the call to chromedriver. Followed the general pattern of the Kimurai file for adding this feature.