### PR TITLE
chromedriver logging now takes in a full file path, not dir

### DIFF
--- a/lib/kimurai/browser_builder/selenium_chrome_builder.rb
+++ b/lib/kimurai/browser_builder/selenium_chrome_builder.rb
@@ -111,14 +111,13 @@ module Kimurai::BrowserBuilder
         end
 
         # Verbose logging to file
-        if chrome_logging_path = @config[:chrome_logging_path]
-          if File.directory?(chrome_logging_path)
-            log_file_path = chrome_logging_path.join("chromium_#{Time.current.strftime('%m_%e_%y_%H_%M_%S')}.log")
+        if log_file_path = @config[:chrome_logging_path]
+          if File.directory?(log_file_path.parent)
             logger.debug "BrowserBuilder (selenium_chrome): enabled verbose logging to #{log_file_path}"
             service_args << '--verbose'
             service_args << "--log-path=#{log_file_path}"
           else
-            logger.error 'BrowserBuilder (selenium_chrome): :chrome_logging_path must be an existing directory'
+            logger.error 'BrowserBuilder (selenium_chrome): :chrome_logging_path must be in an existing directory'
           end
         end
 

--- a/lib/kimurai/version.rb
+++ b/lib/kimurai/version.rb
@@ -1,3 +1,3 @@
 module Kimurai
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
 end


### PR DESCRIPTION
Adjusts the Chromedriver logging argument to now take a full file path and not just a directory. This was initially done as a directory due to how some of the config methods are very obscured between the structure of the anonymous class, super class, and the configuration object not being easily accessible at runtime. 

Bumped version for bundler 